### PR TITLE
Include the error message when throwing an exception

### DIFF
--- a/src/EventListener/RequestListener.php
+++ b/src/EventListener/RequestListener.php
@@ -131,7 +131,7 @@ class RequestListener
             $validator = new MessageValidator();
             $validator->validate($message);
         } catch (\Exception $e) {
-            throw new BadRequestHttpException();
+            throw new BadRequestHttpException($e->getMessage());
         }
 
         $type = $event->getRequest()->headers->get('x-amz-sns-message-type');


### PR DESCRIPTION
For logging purposes, include the error message when throwing `BadRequestHttpException` for an invalid message.
